### PR TITLE
feat: debug shim for scratch containers

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -62,6 +62,10 @@ pub struct Cli {
     #[arg(long)]
     pub install_with_sudo: bool,
 
+    /// create symlinks on the running system. primarily meant to be used for debugging in containers.
+    #[arg(long)]
+    pub install_self: bool,
+
     /// list included binaries
     #[arg(long)]
     pub list: bool,
@@ -151,6 +155,17 @@ pub enum Commands {
         shell: Option<Shell>,
     },
 
+    /// Wraps around the Docker CLI to inject Rizzybox into container
+    /// images. Allows for interactive debugging with minimal containers
+    #[clap(hide = true)]
+    Debug { command: Vec<String> },
+
+    /// Docker CLI expects plugins to return version metadata
+    /// when called with this arg. It is not intended to be
+    /// invoked directly
+    #[clap(hide = true)]
+    DockerCliPluginMetadata {},
+
     /// Output each NAME with its last non-slash component and trailing slashes
     /// removed; if NAME contains no /'s, output '.' (meaning the current directory).
     #[clap(verbatim_doc_comment)]
@@ -235,6 +250,19 @@ pub enum Commands {
     /// Do nothing and exit with a failure status
     False {},
 
+    /// Create symlinks to files (hard links are not supported yet)
+    Ln {
+        #[arg(long, short)]
+        force: bool,
+
+        #[arg(long, short)]
+        symlink: bool,
+
+        source: String,
+
+        destination: String,
+    },
+
     /// List information about the FILEs (the current directory by default)
     Ls {
         /// do not ignore entries starting with '.'
@@ -287,6 +315,11 @@ pub enum Commands {
         #[command(subcommand)]
         command: PathmungeCommand,
     },
+
+    /// Wraps around the Docker CLI to inject Rizzybox into container
+    /// images. Allows for interactive debugging with minimal containers
+    #[clap(hide = true)]
+    Rebug { command: Vec<String> },
 
     /// An incomplete shell
     Sh {},

--- a/src/command/ln.rs
+++ b/src/command/ln.rs
@@ -1,0 +1,18 @@
+pub fn ln_command(force: bool, symlink: bool, source: &str, destination: &str) {
+    if force {
+        // TODO: --force is not implemented yet, but we don't want to panic if the user passes -f
+    }
+
+    if symlink {
+        let symlink_result = std::os::unix::fs::symlink(source, destination);
+        match symlink_result {
+            Ok(_) => {}
+            Err(e) => {
+                eprintln!("Failed to create symlink: {e}");
+                std::process::exit(1);
+            }
+        }
+    } else {
+        todo!("Creating hardlinks is not supported yet...");
+    }
+}

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -6,6 +6,7 @@ pub mod echo;
 pub mod env;
 pub mod expand;
 pub mod r#false;
+pub mod ln;
 pub mod ls;
 pub mod mkdir;
 pub mod nproc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ use std::{fs::remove_file, string::String};
 pub mod consts {
     /// Binaries that can be installed with `--install`
     /// Example: `ln -sf /full/path/to/rizzybox /usr/local/bin/cat`
-    pub const INSTALLABLE_BINS: [&str; 20] = [
+    pub const INSTALLABLE_BINS: [&str; 21] = [
         "arch",
         "basename",
         "cat",
@@ -13,6 +13,7 @@ pub mod consts {
         "env",
         "expand",
         "false",
+        "ln",
         "ls",
         "mkdir",
         "nproc",


### PR DESCRIPTION
# Usage

```sh
sudo ln -sf $(which rizzybox) ~/.docker/cli-plugins/docker-debug
docker debug tangowithfoxtrot/scratch
```

Note that rizzybox must be built with statically linked libc in order to work in scratch or distroless images.